### PR TITLE
Add method to allow isolated use of parsers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,20 +77,20 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-gpg-plugin</artifactId>-->
-                <!--<version>1.6</version>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>sign-artifacts</id>-->
-                        <!--<phase>verify</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>sign</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.julianthome</groupId>
     <artifactId>inmemantlr</artifactId>
-    <version>1.2</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.julianthome</groupId>
     <artifactId>inmemantlr</artifactId>
-    <version>1.0</version>
+    <version>1.2</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -77,20 +77,20 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-gpg-plugin</artifactId>-->
+                <!--<version>1.6</version>-->
+                <!--<executions>-->
+                    <!--<execution>-->
+                        <!--<id>sign-artifacts</id>-->
+                        <!--<phase>verify</phase>-->
+                        <!--<goals>-->
+                            <!--<goal>sign</goal>-->
+                        <!--</goals>-->
+                    <!--</execution>-->
+                <!--</executions>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/src/main/java/org/snt/inmemantlr/GenericParser.java
+++ b/src/main/java/org/snt/inmemantlr/GenericParser.java
@@ -79,6 +79,7 @@ public class GenericParser {
      * constructor
      * @param content grammar file content
      * @param name grammar
+     * @param tlc a ToolCustomizer
      */
     public GenericParser(String content, String name, ToolCustomizer tlc) {
         this.antlr = new Tool();
@@ -126,12 +127,11 @@ public class GenericParser {
      * parse string an create a context
      * @param toParse string to parse
      * @return context
-     * @throws IllegalWorkflowException if listener is null or compilation did not take place
+     * @throws IllegalWorkflowException if compilation did not take place
      */
     public ParserRuleContext parse(String toParse) throws IllegalWorkflowException {
 
         if (listener == null) {
-            //throw new IllegalWorkflowException("Listener is not set");
             this.listener = new DefaultListener();
         }
         if (!antrlObjectsAvailable()) {
@@ -183,13 +183,12 @@ public class GenericParser {
     }
 
     /**
-     * Parse in fresh
-     *
-     * @param toParse
-     * @param listener
+     * parse in fresh
+     * @param toParse string to parse
+     * @param listener a ParseTreeListener
      * @param production Production name to parse
      * @return context
-     * @throws IllegalWorkflowException
+     * @throws IllegalWorkflowException if compilation did not take place
      */
     public ParserRuleContext parse(String toParse, DefaultListener listener, String production) throws IllegalWorkflowException {
 

--- a/src/main/java/org/snt/inmemantlr/SpecialClassLoader.java
+++ b/src/main/java/org/snt/inmemantlr/SpecialClassLoader.java
@@ -35,6 +35,10 @@ class SpecialClassLoader extends ClassLoader {
 
     private Map<String, MemoryByteCode> m = new HashMap<String, MemoryByteCode>();
 
+    public SpecialClassLoader(ClassLoader parent) {
+        super(parent);
+    }
+
     /**
      * find a class that is already loaded
      * @param name class name

--- a/src/main/java/org/snt/inmemantlr/StringCompiler.java
+++ b/src/main/java/org/snt/inmemantlr/StringCompiler.java
@@ -59,7 +59,7 @@ public class StringCompiler {
      * constructors
      */
     public StringCompiler() {
-        this.cl = new SpecialClassLoader();
+        this.cl = new SpecialClassLoader(getClass().getClassLoader());
         this.lexer = new HashMap<>();
         this.parser = new HashMap<>();
         this.mt = new MemoryTupleSet();

--- a/src/main/java/org/snt/inmemantlr/StringCompiler.java
+++ b/src/main/java/org/snt/inmemantlr/StringCompiler.java
@@ -53,7 +53,7 @@ public class StringCompiler {
     private MemoryTupleSet mt = null;
     private Map<String, Lexer> lexer = null;
     private Map<String, Parser> parser = null;
-
+    private Map<String,Class<?>> classes = new HashMap<>();
 
     /**
      * constructors
@@ -155,11 +155,19 @@ public class StringCompiler {
      * @return
      */
     private Class<?> findClass(String cname) {
+        Class clazz;
         try {
-            return this.cl.findClass(cname);
+            if (classes.containsKey(cname)) {
+                clazz = classes.get(cname);
+            } else {
+                clazz = this.cl.findClass(cname);
+                classes.put(cname, clazz);
+            }
         } catch (ClassNotFoundException e) {
             return null;
         }
+
+        return clazz;
     }
 
 

--- a/src/main/java/org/snt/inmemantlr/StringCompiler.java
+++ b/src/main/java/org/snt/inmemantlr/StringCompiler.java
@@ -183,14 +183,7 @@ public class StringCompiler {
 
         String name = cname + "Lexer";
 
-        if (lexer.containsKey(name)) {
-            elexer = lexer.get(name);
-            elexer.reset();
-            return elexer;
-        }
-
         Lexer ret = null;
-
 
         Class<?> elex = findClass(name);
 
@@ -202,7 +195,7 @@ public class StringCompiler {
         assert (cstr.length == 1);
 
         try {
-            //System.out.println(cstr[0].toGenericString());
+            // System.out.println(cstr[0].toGenericString());
             elexer = (Lexer) cstr[0].newInstance(input);
             lexer.put(name, elexer);
         } catch (InstantiationException | IllegalAccessException
@@ -224,12 +217,6 @@ public class StringCompiler {
         String name = cname + "Parser";
 
         Parser eparser = null;
-
-        if (parser.containsKey(name)) {
-            eparser = parser.get(name);
-            eparser.reset();
-            return eparser;
-        }
 
         Parser ret = null;
 
@@ -258,8 +245,4 @@ public class StringCompiler {
     public MemoryTupleSet getAllCompiledObjects() {
         return this.mt;
     }
-
-
-
-
 }

--- a/src/main/java/org/snt/inmemantlr/ToolCustomizer.java
+++ b/src/main/java/org/snt/inmemantlr/ToolCustomizer.java
@@ -1,0 +1,12 @@
+package org.snt.inmemantlr;
+
+import org.antlr.v4.Tool;
+
+/**
+ * Implemented by classes that wish to customize the given Antrl Tool
+ * before use: For example, to add an error listener.
+ */
+public interface ToolCustomizer {
+
+    void customize(Tool t);
+}

--- a/src/main/java/org/snt/inmemantlr/memobjects/MemoryByteCode.java
+++ b/src/main/java/org/snt/inmemantlr/memobjects/MemoryByteCode.java
@@ -87,7 +87,7 @@ public class MemoryByteCode extends MemoryFile implements Serializable {
 
     /**
      * return the class name of this object
-     * @return
+     * @return the class name
      */
     public String getClassName() {
         return this.cname;

--- a/src/main/java/org/snt/inmemantlr/memobjects/MemorySource.java
+++ b/src/main/java/org/snt/inmemantlr/memobjects/MemorySource.java
@@ -55,7 +55,7 @@ public class MemorySource extends MemoryFile implements Serializable {
 
     /**
      * get character content
-     * @param ignoreEncodingErrors
+     * @param ignoreEncodingErrors true to ignore encoding errors, otherwise false
      * @return source as char sequence
      */
     public CharSequence getCharContent(boolean ignoreEncodingErrors) {

--- a/src/test/java/TestAstProcessor.java
+++ b/src/test/java/TestAstProcessor.java
@@ -53,7 +53,7 @@ public class TestAstProcessor {
     @Test
     public void testProcessor() {
 
-        GenericParser gp = new GenericParser(sgrammarcontent, "Java");
+        GenericParser gp = new GenericParser(sgrammarcontent, "Java", null);
         gp.compile();
 
         Assert.assertTrue(s != null && s.length() > 0);

--- a/src/test/java/TestDoubleParse.java
+++ b/src/test/java/TestDoubleParse.java
@@ -21,13 +21,10 @@ import junit.framework.Assert;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.Before;
 import org.junit.Test;
-import org.snt.inmemantlr.DefaultListener;
 import org.snt.inmemantlr.DefaultTreeListener;
 import org.snt.inmemantlr.GenericParser;
 import org.snt.inmemantlr.exceptions.IllegalWorkflowException;
 import org.snt.inmemantlr.tree.Ast;
-import org.snt.inmemantlr.tree.AstNode;
-import org.snt.inmemantlr.tree.AstProcessor;
 import org.snt.inmemantlr.utils.FileUtils;
 
 import java.io.InputStream;
@@ -57,9 +54,9 @@ public class TestDoubleParse {
     @Test
     public void testProcessor() {
 
-        GenericParser gp1 = new GenericParser(sgrammarcontent, "Java");
+        GenericParser gp1 = new GenericParser(sgrammarcontent, "Java", null);
         gp1.compile();
-        GenericParser gp2 = new GenericParser(sgrammarcontent, "Java");
+        GenericParser gp2 = new GenericParser(sgrammarcontent, "Java", null);
         gp2.compile();
 
         DefaultTreeListener l1 = new DefaultTreeListener();

--- a/src/test/java/TestStringCodeGenPipeline.java
+++ b/src/test/java/TestStringCodeGenPipeline.java
@@ -18,17 +18,10 @@
 */
 
 import junit.framework.Assert;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.tool.Grammar;
 import org.junit.Before;
 import org.junit.Test;
-import org.snt.inmemantlr.DefaultTreeListener;
 import org.snt.inmemantlr.GenericParser;
 import org.snt.inmemantlr.StringCodeGenPipeline;
-import org.snt.inmemantlr.exceptions.IllegalWorkflowException;
-import org.snt.inmemantlr.tree.Ast;
-import org.snt.inmemantlr.tree.AstNode;
-import org.snt.inmemantlr.tree.AstProcessor;
 import org.snt.inmemantlr.utils.FileUtils;
 
 import java.io.InputStream;
@@ -55,7 +48,7 @@ public class TestStringCodeGenPipeline {
     @Test
     public void testCodeGenPipeline() {
 
-        GenericParser gp = new GenericParser(sgrammarcontent, "Java");
+        GenericParser gp = new GenericParser(sgrammarcontent, "Java", null);
         gp.compile();
 
         Assert.assertTrue(s != null && s.length() > 0);

--- a/src/test/java/TestStringCompiler.java
+++ b/src/test/java/TestStringCompiler.java
@@ -47,7 +47,7 @@ public class TestStringCompiler {
         sgrammarcontent = FileUtils.getStringFromStream(sgrammar);
         s = FileUtils.getStringFromStream(sfile);
 
-        GenericParser gp = new GenericParser(sgrammarcontent, "Java");
+        GenericParser gp = new GenericParser(sgrammarcontent, "Java", null);
         gp.compile();
 
         Assert.assertTrue(s != null && s.length() > 0);


### PR DESCRIPTION
Nice library! We'd like to use this library at Atomist, but needed to make some enhancements, included in this PR:
- We need to be able to use independent instances of parsers. Added a new method for that.
- We need to be able to pass a parent classloader into SpecialClassLoader, to allow generated classes to see things on the project classpath
- We need to be able to customize the Tool

Alan and I would also be happy to help with polishing, Javadoc etc. overall.

See
https://medium.com/the-composition/software-that-writes-and-evolves-software-953578a6fc36#.8mp4x0p9p for some context.
