### PR TITLE
Fixed typos and removed DefaultListener from overloaded parse method,…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
         <url>https://github.com/julianthome/inmemantlr/tree/master</url>
     </scm>
 
-
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/META-INF/MANIFEST.MF
+++ b/src/main/java/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Main-Class: Polyglot
-

--- a/src/main/java/org/snt/inmemantlr/DefaultListener.java
+++ b/src/main/java/org/snt/inmemantlr/DefaultListener.java
@@ -28,6 +28,7 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * default tree listener
@@ -45,7 +46,6 @@ public class DefaultListener implements ParseTreeListener, Serializable {
      */
     public DefaultListener() {
         parser = null;
-        rmap.clear();
     }
 
     /**
@@ -56,7 +56,7 @@ public class DefaultListener implements ParseTreeListener, Serializable {
      */
     public String getRuleByKey(int key) {
         return rmap.entrySet().stream()
-                .filter(e -> e.getValue() == key)
+                .filter(e -> Objects.equals(e.getValue(), key))
                 .map(Map.Entry::getKey)
                 .findFirst()
                 .orElse(null);

--- a/src/main/java/org/snt/inmemantlr/memobjects/MemoryTupleSet.java
+++ b/src/main/java/org/snt/inmemantlr/memobjects/MemoryTupleSet.java
@@ -49,7 +49,7 @@ public class MemoryTupleSet implements Serializable, Iterable<MemoryTuple> {
     }
 
     /**
-     * add a memory (source,bytecode) tuple to the list
+     * add a memory (source, bytecode) tuple to the list
      *
      * @param source the source code
      * @param bytecode the corresponding bytecode

--- a/src/main/java/org/snt/inmemantlr/utils/EscapeUtils.java
+++ b/src/main/java/org/snt/inmemantlr/utils/EscapeUtils.java
@@ -36,7 +36,7 @@ public final class EscapeUtils {
     }
 
     /**
-     * escape SPECIAL character in a string with a backslash
+     * escape special character in a string with a backslash
      *
      * @param s string to be escaped
      * @return escaped string
@@ -57,7 +57,7 @@ public final class EscapeUtils {
     }
 
     /**
-     * unescape SPECIAL character in a string
+     * unescape special character in a string
      *
      * @param s string to be unescaped
      * @return unescaped string


### PR DESCRIPTION
… as the setListener can be used in its place

Final PR for now, thanks Julian. I removed the listener from the overloaded parse method we added last week. I think it's cleaner just to have callers make use of the setListener method rather than pass it into the parse method. 

If you're OK with all of this, would you please merge and when you have time, do a Maven Central release for 1.1? We can then use it in our repos.
Regards
Alan
