### PR TITLE
Move the logging backend dependency into test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.antlr</groupId>


### PR DESCRIPTION
The backend should not be included in the published artifact allowing the users to choose and configure any backend they prefer.