### PR TITLE
make CompilerOptionsProvider useable

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,40 @@ code:
 // load generic parser from file /tmp/gp.out
 GenericParser gp = GenericParser.load("/tmp/gp.out");
 ```
+## Compiler Options Builder
+
+You can control the options passed to the in-memory Java compiler via `CompilerOptionsBuilder`.
+
+- JDK 9+: prefer `--release`. The builder removes any `-source/-target` and keeps `--release` as the single source of truth.
+- JDK 8 and below: `--release` is not available; the builder falls back to `-source/-target`.
+- Classpath: call `buildClasspath("path")` repeatedly to append. It recognizes synonymous flags (`-classpath`, `-cp`, `--class-path`, `--classpath`) and appends to whichever is present; when adding a new one it normalizes to `-classpath`.
+
+Example:
+
+```java
+import org.snt.inmemantlr.GenericParser;
+import org.snt.inmemantlr.comp.CompilerOptionsBuilder;
+import org.snt.inmemantlr.comp.CompilerOptionsProvider;
+
+GenericParser gp = new GenericParser(new File("MyGrammar.g4"));
+
+CompilerOptionsBuilder b = CompilerOptionsBuilder.builder()
+        .buildRelease("11")              // on JDK 9+; falls back to -source/-target on JDK 8
+        .buildClasspath("/path/to/lib1")
+        .buildClasspath("/path/to/lib2");
+
+CompilerOptionsProvider provider = b.toProvider();
+
+gp.setCompilerOptionsProvider(provider);
+gp.compile();
+```
+
+Notes:
+- The builder joins multiple classpath entries using the platform path separator (`;` on Windows, `:` on Unix-like systems).
+- Avoid mixing `--release` with `-source/-target`; the builder enforces this on JDK 9+.
+
+
+
 
 ## grammars-v4
 
@@ -419,3 +453,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+

--- a/inmemantlr-api/src/main/java/org/snt/inmemantlr/comp/CompilerOptionsBuilder.java
+++ b/inmemantlr-api/src/main/java/org/snt/inmemantlr/comp/CompilerOptionsBuilder.java
@@ -1,0 +1,180 @@
+package org.snt.inmemantlr.comp;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Arrays;
+
+/**
+ * Builder for configuring Java compiler options passed to the in-memory compiler.
+ * Keep options minimal and in the same order they would appear on a javac CLI.
+ */
+public class CompilerOptionsBuilder {
+    private DefaultInnerComplierOptionsProvider optionsProvider = null;
+
+    // Supported classpath flags (synonyms). We normalize to -classpath when adding new.
+    private static final List<String> CLASSPATH_FLAGS = Arrays.asList(
+            "-classpath", "-cp", "--class-path", "--classpath"
+    );
+
+    private static int findClasspathFlagIndex(List<String> opts) {
+        for (String f : CLASSPATH_FLAGS) {
+            int i = opts.indexOf(f);
+            if (i >= 0) return i;
+        }
+        return -1;
+    }
+
+    private CompilerOptionsBuilder(){
+        optionsProvider = new DefaultInnerComplierOptionsProvider();
+    }
+
+    public static CompilerOptionsBuilder builder(){
+        CompilerOptionsBuilder compilerOptionsBuilder = new CompilerOptionsBuilder();
+        return compilerOptionsBuilder;
+    }
+
+    /**
+     * Add or extend the classpath option.
+     * If a classpath flag is not present, add "-classpath" and the provided value.
+     * If present (in any synonymous form), append the new value using the platform path separator.
+     */
+    public CompilerOptionsBuilder buildClasspath(String classpath){
+        if (classpath == null || classpath.isEmpty()) {
+            return this;
+        }
+
+        // Access the underlying list so we can find/modify the value next to the flag
+        @SuppressWarnings("unchecked")
+        List<String> opts = (List<String>) optionsProvider.getOptions();
+        final String defaultFlag = "-classpath"; // normalized when adding
+
+        int idx = findClasspathFlagIndex(opts);
+        if (idx < 0) {
+            // No existing classpath flag: add normalized flag and value
+            optionsProvider.addOption(defaultFlag);
+            optionsProvider.addOption(classpath);
+            return this;
+        }
+
+        // Existing classpath flag: merge the new entry into the value following the flag
+        int valueIndex = idx + 1;
+        String sep = java.io.File.pathSeparator; // ";" on Windows, ":" on *nix
+        if (valueIndex >= opts.size()) {
+            // Malformed options where flag is last; insert the value
+            opts.add(valueIndex, classpath);
+        } else {
+            String old = opts.get(valueIndex);
+            if (old == null || old.isEmpty()) {
+                opts.set(valueIndex, classpath);
+            } else if (old.endsWith(sep)) {
+                opts.set(valueIndex, old + classpath);
+            } else {
+                opts.set(valueIndex, old + sep + classpath);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Prefer using --release on JDK 9+ to ensure language level, bytecode target and JDK API
+     * are aligned. Falls back to -source/-target on older JDKs.
+     */
+    public CompilerOptionsBuilder buildRelease(String release){
+        if (release == null || release.isEmpty()) return this;
+        @SuppressWarnings("unchecked")
+        List<String> opts = (List<String>) optionsProvider.getOptions();
+        if (supportsRelease()) {
+            // Remove -source/-target if present to avoid conflicts
+            removeFlagAndValue(opts, "-source");
+            removeFlagAndValue(opts, "-target");
+            setOrReplace(opts, "--release", release);
+        } else {
+            // JDK 8 and below: fallback to -source/-target
+            setOrReplace(opts, "-source", release);
+            setOrReplace(opts, "-target", release);
+        }
+        return this;
+    }
+
+    public CompilerOptionsBuilder buildSource(String jdkVersion){
+        if (jdkVersion == null || jdkVersion.isEmpty()) return this;
+        @SuppressWarnings("unchecked")
+        List<String> opts = (List<String>) optionsProvider.getOptions();
+        // If --release is already set, prefer keeping it single source of truth
+        if (opts.contains("--release")) return this;
+        setOrReplace(opts, "-source", jdkVersion);
+        return this;
+    }
+
+    public CompilerOptionsBuilder buildTarget(String jdkVersion){
+        if (jdkVersion == null || jdkVersion.isEmpty()) return this;
+        @SuppressWarnings("unchecked")
+        List<String> opts = (List<String>) optionsProvider.getOptions();
+        if (opts.contains("--release")) return this;
+        setOrReplace(opts, "-target", jdkVersion);
+        return this;
+    }
+
+    // Helpers
+    private static boolean supportsRelease() {
+        // java.specification.version returns 1.8 on JDK 8, 9/11/17 on newer
+        String v = System.getProperty("java.specification.version", "");
+        try {
+            int major = v.contains(".") ? Integer.parseInt(v.substring(v.indexOf('.') + 1))
+                                         : Integer.parseInt(v);
+            return major >= 9;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static void setOrReplace(List<String> opts, String flag, String value) {
+        int idx = opts.indexOf(flag);
+        if (idx >= 0) {
+            if (idx + 1 < opts.size()) opts.set(idx + 1, value);
+            else opts.add(value);
+        } else {
+            opts.add(flag);
+            opts.add(value);
+        }
+    }
+
+    private static void removeFlagAndValue(List<String> opts, String flag) {
+        int idx = opts.indexOf(flag);
+        if (idx >= 0) {
+            opts.remove(idx);
+            if (idx < opts.size()) {
+                // remove the value that followed the flag
+                opts.remove(idx);
+            }
+        }
+    }
+
+    /** Return the underlying CompilerOptionsProvider to be used by the compiler. */
+    public CompilerOptionsProvider toProvider(){
+        return optionsProvider;
+    }
+
+    public static class DefaultInnerComplierOptionsProvider implements CompilerOptionsProvider {
+        private final Collection<String> optionList = new ArrayList<>();
+
+        public Collection<String> getClassPath() {
+            return optionList;
+        }
+
+        public void setClassPath(Collection<String> cp) {
+            this.optionList.addAll(cp);
+        }
+
+        /** Add one option token as it would appear on the javac command line. */
+        public void addOption(String option){
+            optionList.add(option);
+        }
+
+        @Override
+        public Collection<String> getOptions() {
+            return optionList;
+        }
+    }
+}

--- a/inmemantlr-api/src/test/java/TestCompilerOptionsBuilder.java
+++ b/inmemantlr-api/src/test/java/TestCompilerOptionsBuilder.java
@@ -1,0 +1,117 @@
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.snt.inmemantlr.comp.CompilerOptionsBuilder;
+import org.snt.inmemantlr.comp.CompilerOptionsProvider;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class TestCompilerOptionsBuilder {
+
+    private static boolean supportsRelease() {
+        String v = System.getProperty("java.specification.version", "");
+        try {
+            int major = v.contains(".") ? Integer.parseInt(v.substring(v.indexOf('.') + 1))
+                    : Integer.parseInt(v);
+            return major >= 9;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Test
+    public void testToProviderAndOptions() {
+        CompilerOptionsBuilder b = CompilerOptionsBuilder.builder()
+                .buildClasspath("A")
+                .buildSource("17");
+        CompilerOptionsProvider p = b.toProvider();
+        Assertions.assertNotNull(p);
+        Collection<String> opts = p.getOptions();
+        Assertions.assertTrue(opts.contains("-classpath") || opts.contains("-cp")
+                || opts.contains("--class-path") || opts.contains("--classpath"));
+        Assertions.assertTrue(opts.contains("-source") || opts.contains("--release"));
+    }
+
+    @Test
+    public void testBuildReleasePrefersRelease() {
+        CompilerOptionsBuilder b = CompilerOptionsBuilder.builder()
+                .buildRelease("8");
+        List<String> opts = new ArrayList<>(b.toProvider().getOptions());
+        if (supportsRelease()) {
+            int i = opts.indexOf("--release");
+            Assertions.assertTrue(i >= 0);
+            Assertions.assertEquals("8", opts.get(i + 1));
+            Assertions.assertFalse(opts.contains("-source"));
+            Assertions.assertFalse(opts.contains("-target"));
+        } else {
+            int s = opts.indexOf("-source");
+            int t = opts.indexOf("-target");
+            Assertions.assertTrue(s >= 0 && t >= 0);
+            Assertions.assertEquals("8", opts.get(s + 1));
+            Assertions.assertEquals("8", opts.get(t + 1));
+        }
+    }
+
+    @Test
+    public void testReleaseThenSourceTarget() {
+        CompilerOptionsBuilder b = CompilerOptionsBuilder.builder()
+                .buildRelease("11")
+                .buildSource("17")
+                .buildTarget("17");
+        List<String> opts = new ArrayList<>(b.toProvider().getOptions());
+        if (supportsRelease()) {
+            int i = opts.indexOf("--release");
+            Assertions.assertTrue(i >= 0);
+            Assertions.assertEquals("11", opts.get(i + 1));
+            Assertions.assertFalse(opts.contains("-source"));
+            Assertions.assertFalse(opts.contains("-target"));
+        } else {
+            int s = opts.indexOf("-source");
+            int t = opts.indexOf("-target");
+            Assertions.assertTrue(s >= 0 && t >= 0);
+            Assertions.assertEquals("17", opts.get(s + 1));
+            Assertions.assertEquals("17", opts.get(t + 1));
+        }
+    }
+
+    @Test
+    public void testClasspathAppendDefaultFlag() {
+        CompilerOptionsBuilder b = CompilerOptionsBuilder.builder()
+                .buildClasspath("FOO")
+                .buildClasspath("BAR");
+        List<String> opts = (List<String>) b.toProvider().getOptions();
+        int i = opts.indexOf("-classpath");
+        Assertions.assertTrue(i >= 0);
+        String expected = "FOO" + File.pathSeparator + "BAR";
+        Assertions.assertEquals(expected, opts.get(i + 1));
+    }
+
+    @Test
+    public void testClasspathAppendOnCpSynonym() {
+        CompilerOptionsBuilder b = CompilerOptionsBuilder.builder();
+        List<String> opts = (List<String>) b.toProvider().getOptions();
+        opts.add("-cp");
+        opts.add("X");
+        b.buildClasspath("Y");
+        int i = opts.indexOf("-cp");
+        Assertions.assertTrue(i >= 0);
+        Assertions.assertEquals("X" + File.pathSeparator + "Y", opts.get(i + 1));
+        // Ensure no extra -classpath flag added
+        Assertions.assertEquals(-1, opts.indexOf("-classpath"));
+    }
+
+    @Test
+    public void testClasspathAppendOnLongSynonym() {
+        CompilerOptionsBuilder b = CompilerOptionsBuilder.builder();
+        List<String> opts = (List<String>) b.toProvider().getOptions();
+        opts.add("--class-path");
+        opts.add("P");
+        b.buildClasspath("Q");
+        int i = opts.indexOf("--class-path");
+        Assertions.assertTrue(i >= 0);
+        Assertions.assertEquals("P" + File.pathSeparator + "Q", opts.get(i + 1));
+        Assertions.assertEquals(-1, opts.indexOf("-classpath"));
+    }
+}


### PR DESCRIPTION
import org.snt.inmemantlr.GenericParser;
import org.snt.inmemantlr.comp.CompilerOptionsBuilder;
import org.snt.inmemantlr.comp.CompilerOptionsProvider;

GenericParser gp = new GenericParser(new File("MyGrammar.g4"));

CompilerOptionsBuilder b = CompilerOptionsBuilder.builder()
        .buildRelease("11")              // on JDK 9+; falls back to -source/-target on JDK 8
        .buildClasspath("/path/to/lib1")
        .buildClasspath("/path/to/lib2");

CompilerOptionsProvider provider = b.toProvider();

gp.setCompilerOptionsProvider(provider);
gp.compile();